### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For more information about how the protocols work in this scenario and other sce
 
 To run this sample you will need:
 - Visual Studio 2013
+- [.NET Framework 4.7](https://www.microsoft.com/net/download/dotnet-framework-runtime/net471) installed
 - An Internet connection
 - An Azure Active Directory (Azure AD) tenant. For more information on how to get an Azure AD tenant, please see [How to get an Azure AD tenant](https://azure.microsoft.com/en-us/documentation/articles/active-directory-howto-tenant/) 
 - A user account in your Azure AD tenant. This sample will not work with a Microsoft account, so if you signed in to the Azure portal with a Microsoft account and have never created a user account in your directory before, you need to do that now.
@@ -38,8 +39,7 @@ There are two projects in this sample.  Each needs to be separately registered i
 4. Click on **App registrations** and choose **Add**.
 5. Enter a friendly name for the application, for example 'TodoListService' and select 'Web Application and/or Web API' as the Application Type. For the sign-on URL, enter the base URL for the sample, which is by default `https://localhost:44321`. Click on **Create** to create the application.
 6. While still in the Azure portal, choose your application, click on **Settings** and choose **Properties**.
-7. Find the Application ID value and copy it to the clipboard.
-8. For the App ID URI, enter https://\<your_tenant_name\>/TodoListService, replacing \<your_tenant_name\> with the name of your Azure AD tenant.
+7. For the App ID URI, enter https://\<your_tenant_name\>/TodoListService, replacing \<your_tenant_name\> with the name of your Azure AD tenant.
 
 #### Register the TodoListWebApp web app
 


### PR DESCRIPTION
added a mention of the required framework 4.7 that some folks may not have installed already
also, no where in either the WebApp or WebApi do we need to paste in the WebApi registration's App ID, mentioned in the first section, step 7 

The web api only needs to reference ida:Tentant and ida:Audience where the URI is used to identify the WebAPI.